### PR TITLE
Make release workflows recoverable

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -51,4 +51,17 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish server metadata
-        run: ./mcp-publisher publish
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 6 ]; then
+              echo "MCP Registry publication failed after ${attempt} attempts."
+              exit 1
+            fi
+
+            echo "Registry dependencies may still be propagating; retrying in 30 seconds (${attempt}/6)."
+            sleep 30
+          done

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing tag to rebuild and upload (for release recovery)
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +23,8 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
@@ -29,9 +36,11 @@ jobs:
       - run: python tools/sync_release_metadata.py --check
       - run: python tools/validate_project.py
       - name: Verify tag matches package version
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         shell: bash
-        run: test "${GITHUB_REF_NAME}" = "v$(python -c 'from bibverify import __version__; print(__version__)')"
+        run: test "${RELEASE_TAG}" = "v$(python -c 'from bibverify import __version__; print(__version__)')"
       - name: Build native executable
         run: >-
           python -m PyInstaller --noconfirm --clean --onefile
@@ -46,7 +55,7 @@ jobs:
           path: release/*
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -60,6 +69,9 @@ jobs:
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
-          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || gh release create "${GITHUB_REF_NAME}" --generate-notes
-          gh release upload "${GITHUB_REF_NAME}" release/* --clobber
+          gh release view "${RELEASE_TAG}" --repo "${GH_REPO}" >/dev/null 2>&1 || \
+            gh release create "${RELEASE_TAG}" --repo "${GH_REPO}" --verify-tag --generate-notes
+          gh release upload "${RELEASE_TAG}" release/* --repo "${GH_REPO}" --clobber

--- a/tests/test_publish_metadata.py
+++ b/tests/test_publish_metadata.py
@@ -42,6 +42,23 @@ class PublishMetadataTests(unittest.TestCase):
         self.assertIn("description:", skill)
         self.assertIn("verify_bib_file", skill)
 
+    def test_standalone_release_targets_the_repository_explicitly(self):
+        workflow = (ROOT / ".github" / "workflows" / "publish-standalone.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("GH_REPO: ${{ github.repository }}", workflow)
+        self.assertIn('--repo "${GH_REPO}"', workflow)
+        self.assertIn("release_tag:", workflow)
+        self.assertIn("ref: ${{ inputs.release_tag || github.ref }}", workflow)
+        self.assertIn("RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}", workflow)
+
+    def test_mcp_publish_retries_registry_dependency_propagation(self):
+        workflow = (ROOT / ".github" / "workflows" / "publish-mcp.yml").read_text(encoding="utf-8")
+
+        self.assertIn("for attempt in 1 2 3 4 5 6", workflow)
+        self.assertIn("sleep 30", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- make the standalone release job target the repository explicitly, so it works without a checkout
- add a recovery input that rebuilds and uploads assets for an existing tag
- retry MCP Registry publication while a freshly uploaded PyPI release propagates
- add regression tests for both release workflow guarantees

## Context

The v0.3.0 tag exposed two last-mile automation issues after all package builds passed:

1. the release job ran outside a Git checkout and `gh release` could not infer the repository
2. MCP Registry validation ran before PyPI 0.3.0 was visible

The recovery input always checks out the specified tag, verifies that its version matches, and uploads only assets built from that tag.

## Validation

- `python -m ruff check src tests tools bib_check.py`
- `python -m ruff format --check src tests tools bib_check.py`
- `python -m mypy`
- `python -m pytest -q` — 84 passed, 3 skipped
- `python tools/sync_release_metadata.py --check`
- `python tools/validate_project.py`
