### PR TITLE
Fix MCP 2.1 errors and align CodeQL updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      codeql-action:
+        applies-to: version-updates
+        patterns:
+          - "github/codeql-action/*"
+      codeql-action-security:
+        applies-to: security-updates
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: npm
     directory: /npm
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
-      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/provider-contract.yml
+++ b/.github/workflows/provider-contract.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           BIBVERIFY_EMAIL: contract-test@example.com
           BIBVERIFY_LIVE_TESTS: "1"
-        run: python -m pytest tests/test_live_contract.py -m live --junitxml=provider-contract.xml
+        run: python -m pytest tests/test_live_contract.py -m live -rs --junitxml=provider-contract.xml
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/src/bibverify/mcp_server.py
+++ b/src/bibverify/mcp_server.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 import anyio
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp_types import LATEST_PROTOCOL_VERSION
 
 from bibverify import __version__
@@ -27,7 +28,7 @@ def _resolve_within(root: Path, value: str | Path, *, label: str) -> Path:
     try:
         path.relative_to(root)
     except ValueError as exc:
-        raise ValueError(f"{label} must stay within the MCP workspace root: {root}") from exc
+        raise ToolError(f"{label} must stay within the configured MCP workspace root") from exc
     return path
 
 
@@ -76,7 +77,7 @@ def create_server(
             service = checker(config_file)
             bibtex = service.bibtex_from_doi(doi, key=key)
         if not bibtex:
-            raise ValueError(service.lang.get_text("doi_not_found", doi=doi))
+            raise ToolError(service.lang.get_text("doi_not_found", doi=doi))
         return {"doi": service.canonicalize_doi(doi), "bibtex": bibtex.strip()}
 
     @server.tool(structured_output=True)

--- a/tests/test_agent_integration.py
+++ b/tests/test_agent_integration.py
@@ -123,6 +123,21 @@ async def test_official_mcp_sdk_lists_and_calls_tools():
     assert result.structured_content["differences"]["title"]["original"] == "Old title"
 
 
+@pytest.mark.anyio
+async def test_mcp_preserves_expected_doi_not_found_error():
+    with patch("bibverify.mcp_server.BibTeXChecker") as checker_class:
+        checker = checker_class.return_value
+        checker.bibtex_from_doi.return_value = None
+        checker.lang.get_text.return_value = "Could not find a reference for DOI: 10.0/missing"
+        server = create_server("__missing_test_config__.json")
+
+        async with Client(server) as client:
+            result = await client.call_tool("doi_to_bibtex", {"doi": "10.0/missing"})
+
+    assert result.is_error
+    assert "Could not find a reference for DOI" in result.content[0].text
+
+
 def test_mcp_rejects_config_outside_workspace(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -140,6 +155,7 @@ def test_mcp_rejects_config_outside_workspace(tmp_path):
     result = anyio.run(call)
     assert result.is_error
     assert "workspace root" in result.content[0].text
+    assert str(workspace) not in result.content[0].text
 
 
 def test_mcp_rejects_config_that_points_outside_workspace(tmp_path):
@@ -156,6 +172,7 @@ def test_mcp_rejects_config_that_points_outside_workspace(tmp_path):
     result = anyio.run(call)
     assert result.is_error
     assert "bib_file must stay" in result.content[0].text
+    assert str(workspace) not in result.content[0].text
 
 
 if __name__ == "__main__":

--- a/tests/test_live_contract.py
+++ b/tests/test_live_contract.py
@@ -7,11 +7,17 @@ import os
 import pytest
 
 from bibverify.checker import BibTeXChecker
-from bibverify.models import QueryStatus
-
-pytestmark = pytest.mark.live
+from bibverify.models import ProviderResult, QueryStatus
 
 
+def _assert_public_doi_result(provider, result):
+    if provider == "semantic_scholar" and result.status is QueryStatus.RATE_LIMITED:
+        pytest.skip(f"{provider} live contract inconclusive (HTTP {result.http_status or 429})")
+
+    assert result.status in {QueryStatus.MATCHED, QueryStatus.AMBIGUOUS}
+
+
+@pytest.mark.live
 @pytest.mark.skipif(not os.getenv("BIBVERIFY_LIVE_TESTS"), reason="scheduled live test only")
 @pytest.mark.parametrize("provider", ["crossref", "openalex", "semantic_scholar"])
 def test_public_doi_contract(provider, tmp_path):
@@ -31,4 +37,39 @@ def test_public_doi_contract(provider, tmp_path):
 
     result = checker.provider_registry[provider].lookup(entry["title"], entry)
 
-    assert result.status in {QueryStatus.MATCHED, QueryStatus.AMBIGUOUS}
+    _assert_public_doi_result(provider, result)
+
+
+def test_semantic_scholar_rate_limit_is_inconclusive():
+    result = ProviderResult("semantic_scholar", QueryStatus.RATE_LIMITED, http_status=429)
+
+    with pytest.raises(pytest.skip.Exception, match=r"semantic_scholar.*429"):
+        _assert_public_doi_result("semantic_scholar", result)
+
+
+def test_other_provider_rate_limit_remains_a_contract_failure():
+    result = ProviderResult("openalex", QueryStatus.RATE_LIMITED, http_status=429)
+
+    with pytest.raises(AssertionError):
+        _assert_public_doi_result("openalex", result)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        QueryStatus.AUTH_ERROR,
+        QueryStatus.NETWORK_ERROR,
+        QueryStatus.PARSE_ERROR,
+        QueryStatus.PROVIDER_ERROR,
+    ],
+)
+def test_semantic_scholar_non_rate_errors_remain_contract_failures(status):
+    result = ProviderResult("semantic_scholar", status)
+
+    with pytest.raises(AssertionError):
+        _assert_public_doi_result("semantic_scholar", result)
+
+
+@pytest.mark.parametrize("status", [QueryStatus.MATCHED, QueryStatus.AMBIGUOUS])
+def test_public_doi_contract_accepts_match_results(status):
+    _assert_public_doi_result("semantic_scholar", ProviderResult("semantic_scholar", status))

--- a/tests/test_project_validation.py
+++ b/tests/test_project_validation.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+import yaml
 from tools.validate_project import (
     validate_action_pins,
     validate_json,
@@ -6,6 +9,8 @@ from tools.validate_project import (
     validate_yaml,
 )
 
+ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_project_metadata_and_links_are_valid():
     validate_json()
@@ -13,3 +18,33 @@ def test_project_metadata_and_links_are_valid():
     validate_yaml()
     validate_action_pins()
     validate_markdown_links()
+
+
+def test_codeql_action_steps_stay_on_one_version():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/codeql.yml").read_text(encoding="utf-8"))
+    uses = [
+        step["uses"]
+        for step in workflow["jobs"]["analyze"]["steps"]
+        if step.get("uses", "").startswith("github/codeql-action/")
+    ]
+    refs = {value.rsplit("@", 1)[1] for value in uses}
+
+    assert len(uses) == 2
+    assert len(refs) == 1
+
+
+def test_dependabot_groups_codeql_version_and_security_updates():
+    config = yaml.safe_load((ROOT / ".github/dependabot.yml").read_text(encoding="utf-8"))
+    github_actions = next(
+        update for update in config["updates"] if update["package-ecosystem"] == "github-actions"
+    )
+    groups = github_actions["groups"]
+
+    assert groups["codeql-action"] == {
+        "applies-to": "version-updates",
+        "patterns": ["github/codeql-action/*"],
+    }
+    assert groups["codeql-action-security"] == {
+        "applies-to": "security-updates",
+        "patterns": ["github/codeql-action/*"],
+    }


### PR DESCRIPTION
## Why

Two independent dependency updates exposed three coupled failures:

- Dependabot split `github/codeql-action/init` and `analyze` into PRs #29 and #30, so either PR alone runs CodeQL with mismatched versions.
- MCP Python SDK 2.1 intentionally hides ordinary exception text; Bibverify's expected workspace rejections and DOI-not-found response still used `ValueError`.
- The scheduled provider contract treated a Semantic Scholar anonymous HTTP 429 as a hard contract regression even though runtime classification already fails safely as `RATE_LIMITED`.

This PR supersedes #29 and #30 with one atomic fix.

## What changed

- Raise MCP `ToolError` only for expected, user-actionable workspace and DOI-not-found failures.
  Unexpected exceptions remain under the SDK's generic error boundary.
- Remove the absolute workspace path from the public rejection text and assert that it is not leaked.
- Treat only `semantic_scholar + RATE_LIMITED` as an inconclusive scheduled sample; every other provider/status remains a failure.
- Show scheduled skip reasons with `pytest -rs` and add deterministic policy tests.
- Align CodeQL `init` and `analyze` on the same pinned v4.37.9 commit.
- Group both version and security updates for `github/codeql-action/*`, with repository tests that require the CodeQL steps to stay aligned.

## Verification

- Python 3.14 / MCP 2.1.1: `101 passed, 3 scheduled-live skipped`.
- MCP 2.0.0 compatibility: the three changed error-boundary tests pass.
- Ruff lint and format checks: pass.
- Mypy: pass.
- Workflow and Dependabot YAML parsing: pass.
- `git diff --check`: pass.

The live network calls were not replayed locally. The deterministic tests prove the policy boundary: Semantic Scholar 429 skips with a visible reason; auth, network, parse, provider, and every non-Semantic-Scholar rate-limit result still fail.
