### PR TITLE
Preserve DOI provider failure status

### DIFF
--- a/src/bibverify/bibtex.py
+++ b/src/bibverify/bibtex.py
@@ -10,6 +10,8 @@ from bibtexparser.bibdatabase import BibDatabase
 from bibtexparser.bparser import BibTexParser
 from bibtexparser.bwriter import BibTexWriter
 
+from bibverify.models import QueryStatus
+
 
 class BibTeXMixin:
     def format_field_value(self, value, protect_case=True):
@@ -633,11 +635,30 @@ class BibTeXMixin:
         key = re.sub(r"[^A-Za-z0-9_:-]+", "_", raw_key).strip("_:-")
         return key or "crossref_entry"
 
-    def bibtex_from_doi(self, doi, key=None):
-        result = self.query_crossref_by_doi(doi)
-        if not result:
-            return None
-        crossref_data = result[1]
+    def bibtex_from_doi_result(self, doi, key=None):
+        """Return generated BibTeX together with the structured Crossref result."""
+        result = self.provider_registry["crossref"].lookup(
+            "", {"ID": "reference", "title": "", "doi": doi}
+        )
+        if result.status is not QueryStatus.MATCHED or not result.best:
+            return None, result
+        crossref_data = result.best.payload
         entry_key = key or self.generate_crossref_key(crossref_data, doi)
         entry = self.crossref_to_bibtex(crossref_data, entry_key)
-        return self.entry_to_bibtex(entry)
+        return self.entry_to_bibtex(entry), result
+
+    def doi_lookup_failure_message(self, doi, result):
+        """Return a stable public message without exposing provider error details."""
+        if result.status is QueryStatus.RATE_LIMITED:
+            return self.lang.get_text("rate_limit_429", platform="Crossref")
+        if result.status is QueryStatus.IDENTIFIER_CONFLICT:
+            return self.lang.get_text("doi_identifier_conflict", doi=doi)
+        if result.status.is_unavailable:
+            return self.lang.get_text(
+                "source_unavailable", platform="Crossref", status=result.status.value
+            )
+        return self.lang.get_text("doi_not_found", doi=doi)
+
+    def bibtex_from_doi(self, doi, key=None):
+        bibtex, _ = self.bibtex_from_doi_result(doi, key=key)
+        return bibtex

--- a/src/bibverify/cli.py
+++ b/src/bibverify/cli.py
@@ -25,6 +25,7 @@ from bibverify.benchmark import run_benchmark
 from bibverify.cache import ResponseCache
 from bibverify.checker import BibTeXChecker
 from bibverify.config import create_config, load_config
+from bibverify.models import QueryStatus
 
 app = typer.Typer(
     name="bibverify",
@@ -171,9 +172,13 @@ def doi(
     """Resolve one DOI to a BibTeX entry."""
     with redirect_stdout(StringIO()):
         checker = BibTeXChecker(config)
-        bibtex = checker.bibtex_from_doi(value, key=key)
+        bibtex, lookup = checker.bibtex_from_doi_result(value, key=key)
     if not bibtex:
-        error_console.print(checker.lang.get_text("doi_not_found", doi=value))
+        error_console.print(checker.doi_lookup_failure_message(value, lookup))
+        if lookup.status.is_unavailable:
+            raise typer.Exit(code=4)
+        if lookup.status is QueryStatus.IDENTIFIER_CONFLICT:
+            raise typer.Exit(code=3)
         raise typer.Exit(code=1)
     if json_output:
         typer.echo(

--- a/src/bibverify/i18n.py
+++ b/src/bibverify/i18n.py
@@ -53,6 +53,8 @@ TEXTS = {
         "no_wrong_skip": "[3/3] 无待复核条目，跳过生成 review 文件",
         "missing_optional_dependency": "{platform} 可选依赖缺失: {dependency}，请安装后重试或禁用该平台",
         "doi_not_found": "未能通过 DOI 找到文献: {doi}",
+        "doi_identifier_conflict": "Crossref 返回的 DOI 与请求标识符冲突: {doi}",
+        "source_unavailable": "{platform} 数据源暂时不可用: {status}",
         "skip_enrichment_only": "[{platform}] ✗ 跳过（仅用于开放获取补充，不作为文献元数据源）",
     },
     "EN": {
@@ -103,6 +105,8 @@ TEXTS = {
         "no_wrong_skip": "[3/3] No review entries, skipping review file generation",
         "missing_optional_dependency": "{platform} optional dependency missing: {dependency}; install it or disable the platform",
         "doi_not_found": "Could not find a reference for DOI: {doi}",
+        "doi_identifier_conflict": "Crossref returned a DOI that conflicts with: {doi}",
+        "source_unavailable": "{platform} source unavailable: {status}",
         "skip_enrichment_only": "[{platform}] ✗ Skipped (open-access enrichment only, not bibliographic metadata)",
     },
 }

--- a/src/bibverify/mcp_server.py
+++ b/src/bibverify/mcp_server.py
@@ -75,9 +75,9 @@ def create_server(
         """Fetch one DOI through Crossref and return a BibTeX entry."""
         with redirect_stdout(io.StringIO()):
             service = checker(config_file)
-            bibtex = service.bibtex_from_doi(doi, key=key)
+            bibtex, lookup = service.bibtex_from_doi_result(doi, key=key)
         if not bibtex:
-            raise ToolError(service.lang.get_text("doi_not_found", doi=doi))
+            raise ToolError(service.doi_lookup_failure_message(doi, lookup))
         return {"doi": service.canonicalize_doi(doi), "bibtex": bibtex.strip()}
 
     @server.tool(structured_output=True)
@@ -151,11 +151,10 @@ def _call_compat(name: str, arguments: dict[str, Any], default_config: str) -> d
     with redirect_stdout(io.StringIO()):
         checker = BibTeXChecker(config_file)
         if name == "doi_to_bibtex":
-            bibtex = checker.bibtex_from_doi(arguments.get("doi", ""), key=arguments.get("key"))
+            doi = arguments.get("doi", "")
+            bibtex, lookup = checker.bibtex_from_doi_result(doi, key=arguments.get("key"))
             if not bibtex:
-                return _text_result(
-                    checker.lang.get_text("doi_not_found", doi=arguments.get("doi", "")), True
-                )
+                return _text_result(checker.doi_lookup_failure_message(doi, lookup), True)
             return _text_result(bibtex.strip(), structured={"bibtex": bibtex.strip()})
         if name == "rank_lookup_sources":
             order = checker._rank_platforms_for_entry(

--- a/tests/test_agent_integration.py
+++ b/tests/test_agent_integration.py
@@ -13,6 +13,7 @@ from mcp_types import LATEST_PROTOCOL_VERSION
 
 from bibverify.agent import build_mcp_config, build_skill_markdown, doctor, init_agent
 from bibverify.mcp_server import create_server, handle_request, run_stdio_server
+from bibverify.models import ProviderResult, QueryStatus
 
 
 class AgentIntegrationTests(unittest.TestCase):
@@ -127,8 +128,13 @@ async def test_official_mcp_sdk_lists_and_calls_tools():
 async def test_mcp_preserves_expected_doi_not_found_error():
     with patch("bibverify.mcp_server.BibTeXChecker") as checker_class:
         checker = checker_class.return_value
-        checker.bibtex_from_doi.return_value = None
-        checker.lang.get_text.return_value = "Could not find a reference for DOI: 10.0/missing"
+        checker.bibtex_from_doi_result.return_value = (
+            None,
+            ProviderResult("crossref", QueryStatus.NO_MATCH),
+        )
+        checker.doi_lookup_failure_message.return_value = (
+            "Could not find a reference for DOI: 10.0/missing"
+        )
         server = create_server("__missing_test_config__.json")
 
         async with Client(server) as client:
@@ -136,6 +142,87 @@ async def test_mcp_preserves_expected_doi_not_found_error():
 
     assert result.is_error
     assert "Could not find a reference for DOI" in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_mcp_does_not_report_crossref_rate_limit_as_doi_not_found():
+    with patch("bibverify.mcp_server.BibTeXChecker") as checker_class:
+        checker = checker_class.return_value
+        checker.bibtex_from_doi_result.return_value = (
+            None,
+            ProviderResult("crossref", QueryStatus.RATE_LIMITED, http_status=429),
+        )
+        checker.doi_lookup_failure_message.return_value = (
+            "Crossref rate limit - recommend adding API key"
+        )
+        server = create_server("__missing_test_config__.json")
+
+        async with Client(server) as client:
+            result = await client.call_tool("doi_to_bibtex", {"doi": "10.0/rate-limited"})
+
+    assert result.is_error
+    assert "rate limit" in result.content[0].text
+    assert "not find" not in result.content[0].text
+
+
+def test_compat_mcp_preserves_crossref_rate_limit_status():
+    with patch("bibverify.mcp_server.BibTeXChecker") as checker_class:
+        checker = checker_class.return_value
+        checker.bibtex_from_doi_result.return_value = (
+            None,
+            ProviderResult("crossref", QueryStatus.RATE_LIMITED, http_status=429),
+        )
+        checker.doi_lookup_failure_message.return_value = (
+            "Crossref rate limit - recommend adding API key"
+        )
+        response = handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "doi_to_bibtex",
+                    "arguments": {"doi": "10.0/rate-limited"},
+                },
+            }
+        )
+
+    text = response["result"]["content"][0]["text"]
+    assert response["result"]["isError"] is True
+    assert "rate limit" in text
+    assert "not find" not in text
+
+
+@pytest.mark.anyio
+async def test_mcp_and_compat_reject_crossref_identifier_conflict():
+    with patch("bibverify.mcp_server.BibTeXChecker") as checker_class:
+        checker = checker_class.return_value
+        checker.bibtex_from_doi_result.return_value = (
+            None,
+            ProviderResult("crossref", QueryStatus.IDENTIFIER_CONFLICT),
+        )
+        checker.doi_lookup_failure_message.return_value = "Crossref DOI conflict"
+        server = create_server("__missing_test_config__.json")
+
+        async with Client(server) as client:
+            official = await client.call_tool("doi_to_bibtex", {"doi": "10.0/conflict"})
+
+        compat = handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "doi_to_bibtex",
+                    "arguments": {"doi": "10.0/conflict"},
+                },
+            }
+        )
+
+    assert official.is_error
+    assert "conflict" in official.content[0].text
+    assert compat["result"]["isError"] is True
+    assert "conflict" in compat["result"]["content"][0]["text"]
 
 
 def test_mcp_rejects_config_outside_workspace(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from bibverify.cli import _translate_legacy_args, app
+from bibverify.models import ProviderResult, QueryStatus
 
 runner = CliRunner()
 
@@ -105,3 +106,33 @@ def test_invalid_input_uses_documented_exit_code(tmp_path):
     result = runner.invoke(app, ["check", str(missing), "--dry-run"])
 
     assert result.exit_code == 5
+
+
+def test_doi_rate_limit_uses_source_unavailable_exit_code():
+    with patch("bibverify.cli.BibTeXChecker") as checker_class:
+        checker = checker_class.return_value
+        checker.bibtex_from_doi_result.return_value = (
+            None,
+            ProviderResult("crossref", QueryStatus.RATE_LIMITED, http_status=429),
+        )
+        checker.doi_lookup_failure_message.return_value = (
+            "Crossref rate limit - recommend adding API key"
+        )
+        result = runner.invoke(app, ["doi", "10.0/rate-limited"])
+
+    assert result.exit_code == 4
+    assert "rate limit" in result.stderr
+
+
+def test_doi_identifier_conflict_uses_review_required_exit_code():
+    with patch("bibverify.cli.BibTeXChecker") as checker_class:
+        checker = checker_class.return_value
+        checker.bibtex_from_doi_result.return_value = (
+            None,
+            ProviderResult("crossref", QueryStatus.IDENTIFIER_CONFLICT),
+        )
+        checker.doi_lookup_failure_message.return_value = "Crossref DOI conflict"
+        result = runner.invoke(app, ["doi", "10.0/conflict"])
+
+    assert result.exit_code == 3
+    assert "conflict" in result.stderr

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -47,6 +47,44 @@ def test_crossref_fixture_extracts_candidate_and_doi(checker, requests_mock):
     assert result.best.entry["doi"] == "10.1000/reliable"
 
 
+def test_doi_bibtex_preserves_crossref_rate_limit_status(checker, requests_mock):
+    requests_mock.get("https://api.crossref.org/works/10.1000%2Frate-limited", status_code=429)
+
+    bibtex, result = checker.bibtex_from_doi_result("10.1000/rate-limited")
+
+    assert bibtex is None
+    assert result.status is QueryStatus.RATE_LIMITED
+    message = checker.doi_lookup_failure_message("10.1000/rate-limited", result)
+    assert message != checker.lang.get_text("doi_not_found", doi="10.1000/rate-limited")
+    assert "https://" not in message
+
+
+def test_doi_bibtex_result_preserves_successful_generation(checker, requests_mock):
+    payload = load_json("crossref", "search.json")["message"]["items"][0]
+    requests_mock.get(
+        "https://api.crossref.org/works/10.1000%2Freliable", json={"message": payload}
+    )
+
+    bibtex, result = checker.bibtex_from_doi_result("10.1000/reliable", key="fixture-key")
+
+    assert result.status is QueryStatus.MATCHED
+    assert "@article{fixture-key," in bibtex
+    assert checker.bibtex_from_doi("10.1000/reliable", key="fixture-key") == bibtex
+
+
+def test_doi_bibtex_rejects_identifier_conflict(checker, requests_mock):
+    payload = load_json("crossref", "search.json")["message"]["items"][0]
+    requests_mock.get(
+        "https://api.crossref.org/works/10.1000%2Fdifferent", json={"message": payload}
+    )
+
+    bibtex, result = checker.bibtex_from_doi_result("10.1000/different")
+
+    assert bibtex is None
+    assert result.status is QueryStatus.IDENTIFIER_CONFLICT
+    assert "冲突" in checker.doi_lookup_failure_message("10.1000/different", result)
+
+
 def test_openalex_fixture_extracts_pages_and_provider_status(checker, requests_mock):
     requests_mock.get("https://api.openalex.org/works", json=load_json("openalex", "search.json"))
 


### PR DESCRIPTION
## Why

The MCP 2.1 compatibility fix made expected DOI failures visible again, which exposed a legacy information-loss bug: `bibtex_from_doi()` collapsed every unsuccessful Crossref result to `None`. A rate limit, authentication/network failure, or identifier conflict could therefore be reported as “DOI not found”.

## What changed

- Add `bibtex_from_doi_result()` so transports retain the structured Crossref `ProviderResult`.
- Generate BibTeX only for `MATCHED`; an `IDENTIFIER_CONFLICT` candidate can no longer be emitted as a successful citation.
- Return stable, localized public messages for rate limits, provider unavailability, conflicts, and genuine no-match results without exposing raw provider errors or URLs.
- Keep the legacy `bibtex_from_doi()` success API by delegating to the structured method.
- CLI now uses exit code 3 for identifier conflict, 4 for source unavailable, and 1 for genuine not-found.
- Official MCP and the compatibility JSON-lines adapter preserve the same distinctions.

## Verification

- Full suite: `109 passed, 3 scheduled-live skipped`.
- MCP 2.0.0 and 2.1.1 error-boundary checks pass.
- Explicit provider, CLI, official MCP, and compatibility MCP regressions cover rate limiting and identifier conflicts.
- Successful DOI-to-BibTeX generation remains covered.
- Ruff, format check, Mypy, and `git diff --check` pass.
